### PR TITLE
tweak double hammer test case

### DIFF
--- a/double_sided_rowhammer.cc
+++ b/double_sided_rowhammer.cc
@@ -195,7 +195,7 @@ uint64_t HammerAddressesStandard(
     uint64_t number_of_reads) {
   uint64_t* first_pointer = reinterpret_cast<uint64_t*>(first_range.first);
   uint64_t* second_pointer = reinterpret_cast<uint64_t*>(second_range.first);
-  volatile uint64_t sum = 0;
+  uint64_t sum = 0;
 
   while (number_of_reads-- > 0) {
     sum += first_pointer[0];
@@ -272,7 +272,7 @@ uint64_t HammerAllReachablePages(uint64_t presumed_row_size,
           memset(target_page, 0xFF, 0x1000);
         }
         // Test sleep code to see how this affects the distribution.
-        sleep(1);
+        //sleep(1);
         // Now hammer the two pages we care about.
         std::pair<uint64_t, uint64_t> first_page_range(
             reinterpret_cast<uint64_t>(first_row_page), 

--- a/make.sh
+++ b/make.sh
@@ -17,3 +17,4 @@
 set -eu
 
 g++ -g -Wall -Werror -O2 rowhammer_test.cc -o rowhammer_test
+g++ -g --std=c++11 -Wall  -O2 double_sided_rowhammer.cc -o double_sided_rowhammer


### PR DESCRIPTION
I had to remove the "volatile" from the double hammer test case sum variable to eliminate extra stack variable memory accesses from the hammer loop.  I also got rid of the extra sleep, which seems to serve no purpose (am I wrong?) and I added a line for building the double hammer test to make.sh.
